### PR TITLE
allow https access to firmware files

### DIFF
--- a/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
@@ -34,6 +34,9 @@ http {
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;
 
+        location /data/tasmoadmin/firmwares {
+        }
+
         location /data/ {
             deny all;
         }


### PR DESCRIPTION
# Proposed Changes

add:
 location /data/tasmoadmin/firmwares {
        }
to be consistent with parent project repo to allow access to the firmware files via https.